### PR TITLE
IDF release/v5.1

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-bd2b9390ef"
+              "version": "idf-release_v5.1-bae9a3a29f"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-bd2b9390ef",
+          "version": "idf-release_v5.1-bae9a3a29f",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c4ae7a78eafc339c71efcc7a75d5caa525c92f58",
-              "archiveFileName": "esp32-arduino-libs-c4ae7a78eafc339c71efcc7a75d5caa525c92f58.zip",
-              "checksum": "SHA-256:bd9d095d468b517e9836355246cff536223b456aa67ffdb176e167c368ddfd1f",
-              "size": "307841384"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c59093ff4218013189265d5d62ef776ba81892d4",
+              "archiveFileName": "esp32-arduino-libs-c59093ff4218013189265d5d62ef776ba81892d4.zip",
+              "checksum": "SHA-256:e52454ac705d941d7617860c9163904676c3562136b964d8dea91cc7386a5630",
+              "size": "307496448"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c4ae7a78eafc339c71efcc7a75d5caa525c92f58",
-              "archiveFileName": "esp32-arduino-libs-c4ae7a78eafc339c71efcc7a75d5caa525c92f58.zip",
-              "checksum": "SHA-256:bd9d095d468b517e9836355246cff536223b456aa67ffdb176e167c368ddfd1f",
-              "size": "307841384"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c59093ff4218013189265d5d62ef776ba81892d4",
+              "archiveFileName": "esp32-arduino-libs-c59093ff4218013189265d5d62ef776ba81892d4.zip",
+              "checksum": "SHA-256:e52454ac705d941d7617860c9163904676c3562136b964d8dea91cc7386a5630",
+              "size": "307496448"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c4ae7a78eafc339c71efcc7a75d5caa525c92f58",
-              "archiveFileName": "esp32-arduino-libs-c4ae7a78eafc339c71efcc7a75d5caa525c92f58.zip",
-              "checksum": "SHA-256:bd9d095d468b517e9836355246cff536223b456aa67ffdb176e167c368ddfd1f",
-              "size": "307841384"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c59093ff4218013189265d5d62ef776ba81892d4",
+              "archiveFileName": "esp32-arduino-libs-c59093ff4218013189265d5d62ef776ba81892d4.zip",
+              "checksum": "SHA-256:e52454ac705d941d7617860c9163904676c3562136b964d8dea91cc7386a5630",
+              "size": "307496448"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c4ae7a78eafc339c71efcc7a75d5caa525c92f58",
-              "archiveFileName": "esp32-arduino-libs-c4ae7a78eafc339c71efcc7a75d5caa525c92f58.zip",
-              "checksum": "SHA-256:bd9d095d468b517e9836355246cff536223b456aa67ffdb176e167c368ddfd1f",
-              "size": "307841384"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c59093ff4218013189265d5d62ef776ba81892d4",
+              "archiveFileName": "esp32-arduino-libs-c59093ff4218013189265d5d62ef776ba81892d4.zip",
+              "checksum": "SHA-256:e52454ac705d941d7617860c9163904676c3562136b964d8dea91cc7386a5630",
+              "size": "307496448"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c4ae7a78eafc339c71efcc7a75d5caa525c92f58",
-              "archiveFileName": "esp32-arduino-libs-c4ae7a78eafc339c71efcc7a75d5caa525c92f58.zip",
-              "checksum": "SHA-256:bd9d095d468b517e9836355246cff536223b456aa67ffdb176e167c368ddfd1f",
-              "size": "307841384"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c59093ff4218013189265d5d62ef776ba81892d4",
+              "archiveFileName": "esp32-arduino-libs-c59093ff4218013189265d5d62ef776ba81892d4.zip",
+              "checksum": "SHA-256:e52454ac705d941d7617860c9163904676c3562136b964d8dea91cc7386a5630",
+              "size": "307496448"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c4ae7a78eafc339c71efcc7a75d5caa525c92f58",
-              "archiveFileName": "esp32-arduino-libs-c4ae7a78eafc339c71efcc7a75d5caa525c92f58.zip",
-              "checksum": "SHA-256:bd9d095d468b517e9836355246cff536223b456aa67ffdb176e167c368ddfd1f",
-              "size": "307841384"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c59093ff4218013189265d5d62ef776ba81892d4",
+              "archiveFileName": "esp32-arduino-libs-c59093ff4218013189265d5d62ef776ba81892d4.zip",
+              "checksum": "SHA-256:e52454ac705d941d7617860c9163904676c3562136b964d8dea91cc7386a5630",
+              "size": "307496448"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c4ae7a78eafc339c71efcc7a75d5caa525c92f58",
-              "archiveFileName": "esp32-arduino-libs-c4ae7a78eafc339c71efcc7a75d5caa525c92f58.zip",
-              "checksum": "SHA-256:bd9d095d468b517e9836355246cff536223b456aa67ffdb176e167c368ddfd1f",
-              "size": "307841384"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c59093ff4218013189265d5d62ef776ba81892d4",
+              "archiveFileName": "esp32-arduino-libs-c59093ff4218013189265d5d62ef776ba81892d4.zip",
+              "checksum": "SHA-256:e52454ac705d941d7617860c9163904676c3562136b964d8dea91cc7386a5630",
+              "size": "307496448"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c4ae7a78eafc339c71efcc7a75d5caa525c92f58",
-              "archiveFileName": "esp32-arduino-libs-c4ae7a78eafc339c71efcc7a75d5caa525c92f58.zip",
-              "checksum": "SHA-256:bd9d095d468b517e9836355246cff536223b456aa67ffdb176e167c368ddfd1f",
-              "size": "307841384"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c59093ff4218013189265d5d62ef776ba81892d4",
+              "archiveFileName": "esp32-arduino-libs-c59093ff4218013189265d5d62ef776ba81892d4.zip",
+              "checksum": "SHA-256:e52454ac705d941d7617860c9163904676c3562136b964d8dea91cc7386a5630",
+              "size": "307496448"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-bae9a3a29f"
+              "version": "idf-release_v5.1-dc859c1e67"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-bae9a3a29f",
+          "version": "idf-release_v5.1-dc859c1e67",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c59093ff4218013189265d5d62ef776ba81892d4",
-              "archiveFileName": "esp32-arduino-libs-c59093ff4218013189265d5d62ef776ba81892d4.zip",
-              "checksum": "SHA-256:e52454ac705d941d7617860c9163904676c3562136b964d8dea91cc7386a5630",
-              "size": "307496448"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/0aad7265be78064dd74d0e9f07147e5b57fe1bf1",
+              "archiveFileName": "esp32-arduino-libs-0aad7265be78064dd74d0e9f07147e5b57fe1bf1.zip",
+              "checksum": "SHA-256:3119601b06dfcfd4cd21b677dbaa593bf9f585966981a5902f86eeb675ab1c92",
+              "size": "307529720"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c59093ff4218013189265d5d62ef776ba81892d4",
-              "archiveFileName": "esp32-arduino-libs-c59093ff4218013189265d5d62ef776ba81892d4.zip",
-              "checksum": "SHA-256:e52454ac705d941d7617860c9163904676c3562136b964d8dea91cc7386a5630",
-              "size": "307496448"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/0aad7265be78064dd74d0e9f07147e5b57fe1bf1",
+              "archiveFileName": "esp32-arduino-libs-0aad7265be78064dd74d0e9f07147e5b57fe1bf1.zip",
+              "checksum": "SHA-256:3119601b06dfcfd4cd21b677dbaa593bf9f585966981a5902f86eeb675ab1c92",
+              "size": "307529720"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c59093ff4218013189265d5d62ef776ba81892d4",
-              "archiveFileName": "esp32-arduino-libs-c59093ff4218013189265d5d62ef776ba81892d4.zip",
-              "checksum": "SHA-256:e52454ac705d941d7617860c9163904676c3562136b964d8dea91cc7386a5630",
-              "size": "307496448"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/0aad7265be78064dd74d0e9f07147e5b57fe1bf1",
+              "archiveFileName": "esp32-arduino-libs-0aad7265be78064dd74d0e9f07147e5b57fe1bf1.zip",
+              "checksum": "SHA-256:3119601b06dfcfd4cd21b677dbaa593bf9f585966981a5902f86eeb675ab1c92",
+              "size": "307529720"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c59093ff4218013189265d5d62ef776ba81892d4",
-              "archiveFileName": "esp32-arduino-libs-c59093ff4218013189265d5d62ef776ba81892d4.zip",
-              "checksum": "SHA-256:e52454ac705d941d7617860c9163904676c3562136b964d8dea91cc7386a5630",
-              "size": "307496448"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/0aad7265be78064dd74d0e9f07147e5b57fe1bf1",
+              "archiveFileName": "esp32-arduino-libs-0aad7265be78064dd74d0e9f07147e5b57fe1bf1.zip",
+              "checksum": "SHA-256:3119601b06dfcfd4cd21b677dbaa593bf9f585966981a5902f86eeb675ab1c92",
+              "size": "307529720"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c59093ff4218013189265d5d62ef776ba81892d4",
-              "archiveFileName": "esp32-arduino-libs-c59093ff4218013189265d5d62ef776ba81892d4.zip",
-              "checksum": "SHA-256:e52454ac705d941d7617860c9163904676c3562136b964d8dea91cc7386a5630",
-              "size": "307496448"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/0aad7265be78064dd74d0e9f07147e5b57fe1bf1",
+              "archiveFileName": "esp32-arduino-libs-0aad7265be78064dd74d0e9f07147e5b57fe1bf1.zip",
+              "checksum": "SHA-256:3119601b06dfcfd4cd21b677dbaa593bf9f585966981a5902f86eeb675ab1c92",
+              "size": "307529720"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c59093ff4218013189265d5d62ef776ba81892d4",
-              "archiveFileName": "esp32-arduino-libs-c59093ff4218013189265d5d62ef776ba81892d4.zip",
-              "checksum": "SHA-256:e52454ac705d941d7617860c9163904676c3562136b964d8dea91cc7386a5630",
-              "size": "307496448"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/0aad7265be78064dd74d0e9f07147e5b57fe1bf1",
+              "archiveFileName": "esp32-arduino-libs-0aad7265be78064dd74d0e9f07147e5b57fe1bf1.zip",
+              "checksum": "SHA-256:3119601b06dfcfd4cd21b677dbaa593bf9f585966981a5902f86eeb675ab1c92",
+              "size": "307529720"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c59093ff4218013189265d5d62ef776ba81892d4",
-              "archiveFileName": "esp32-arduino-libs-c59093ff4218013189265d5d62ef776ba81892d4.zip",
-              "checksum": "SHA-256:e52454ac705d941d7617860c9163904676c3562136b964d8dea91cc7386a5630",
-              "size": "307496448"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/0aad7265be78064dd74d0e9f07147e5b57fe1bf1",
+              "archiveFileName": "esp32-arduino-libs-0aad7265be78064dd74d0e9f07147e5b57fe1bf1.zip",
+              "checksum": "SHA-256:3119601b06dfcfd4cd21b677dbaa593bf9f585966981a5902f86eeb675ab1c92",
+              "size": "307529720"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c59093ff4218013189265d5d62ef776ba81892d4",
-              "archiveFileName": "esp32-arduino-libs-c59093ff4218013189265d5d62ef776ba81892d4.zip",
-              "checksum": "SHA-256:e52454ac705d941d7617860c9163904676c3562136b964d8dea91cc7386a5630",
-              "size": "307496448"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/0aad7265be78064dd74d0e9f07147e5b57fe1bf1",
+              "archiveFileName": "esp32-arduino-libs-0aad7265be78064dd74d0e9f07147e5b57fe1bf1.zip",
+              "checksum": "SHA-256:3119601b06dfcfd4cd21b677dbaa593bf9f585966981a5902f86eeb675ab1c92",
+              "size": "307529720"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-dc859c1e67"
+              "version": "idf-release_v5.1-b084048f"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-dc859c1e67",
+          "version": "idf-release_v5.1-b084048f",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/0aad7265be78064dd74d0e9f07147e5b57fe1bf1",
-              "archiveFileName": "esp32-arduino-libs-0aad7265be78064dd74d0e9f07147e5b57fe1bf1.zip",
-              "checksum": "SHA-256:3119601b06dfcfd4cd21b677dbaa593bf9f585966981a5902f86eeb675ab1c92",
-              "size": "307529720"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-b084048f.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-b084048f.zip",
+              "checksum": "SHA-256:a53a555a42613b536af93c3b7f7465921284fc35377a7fac26f46660f4902e05",
+              "size": ""
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/0aad7265be78064dd74d0e9f07147e5b57fe1bf1",
-              "archiveFileName": "esp32-arduino-libs-0aad7265be78064dd74d0e9f07147e5b57fe1bf1.zip",
-              "checksum": "SHA-256:3119601b06dfcfd4cd21b677dbaa593bf9f585966981a5902f86eeb675ab1c92",
-              "size": "307529720"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-b084048f.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-b084048f.zip",
+              "checksum": "SHA-256:a53a555a42613b536af93c3b7f7465921284fc35377a7fac26f46660f4902e05",
+              "size": ""
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/0aad7265be78064dd74d0e9f07147e5b57fe1bf1",
-              "archiveFileName": "esp32-arduino-libs-0aad7265be78064dd74d0e9f07147e5b57fe1bf1.zip",
-              "checksum": "SHA-256:3119601b06dfcfd4cd21b677dbaa593bf9f585966981a5902f86eeb675ab1c92",
-              "size": "307529720"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-b084048f.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-b084048f.zip",
+              "checksum": "SHA-256:a53a555a42613b536af93c3b7f7465921284fc35377a7fac26f46660f4902e05",
+              "size": ""
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/0aad7265be78064dd74d0e9f07147e5b57fe1bf1",
-              "archiveFileName": "esp32-arduino-libs-0aad7265be78064dd74d0e9f07147e5b57fe1bf1.zip",
-              "checksum": "SHA-256:3119601b06dfcfd4cd21b677dbaa593bf9f585966981a5902f86eeb675ab1c92",
-              "size": "307529720"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-b084048f.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-b084048f.zip",
+              "checksum": "SHA-256:a53a555a42613b536af93c3b7f7465921284fc35377a7fac26f46660f4902e05",
+              "size": ""
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/0aad7265be78064dd74d0e9f07147e5b57fe1bf1",
-              "archiveFileName": "esp32-arduino-libs-0aad7265be78064dd74d0e9f07147e5b57fe1bf1.zip",
-              "checksum": "SHA-256:3119601b06dfcfd4cd21b677dbaa593bf9f585966981a5902f86eeb675ab1c92",
-              "size": "307529720"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-b084048f.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-b084048f.zip",
+              "checksum": "SHA-256:a53a555a42613b536af93c3b7f7465921284fc35377a7fac26f46660f4902e05",
+              "size": ""
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/0aad7265be78064dd74d0e9f07147e5b57fe1bf1",
-              "archiveFileName": "esp32-arduino-libs-0aad7265be78064dd74d0e9f07147e5b57fe1bf1.zip",
-              "checksum": "SHA-256:3119601b06dfcfd4cd21b677dbaa593bf9f585966981a5902f86eeb675ab1c92",
-              "size": "307529720"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-b084048f.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-b084048f.zip",
+              "checksum": "SHA-256:a53a555a42613b536af93c3b7f7465921284fc35377a7fac26f46660f4902e05",
+              "size": ""
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/0aad7265be78064dd74d0e9f07147e5b57fe1bf1",
-              "archiveFileName": "esp32-arduino-libs-0aad7265be78064dd74d0e9f07147e5b57fe1bf1.zip",
-              "checksum": "SHA-256:3119601b06dfcfd4cd21b677dbaa593bf9f585966981a5902f86eeb675ab1c92",
-              "size": "307529720"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-b084048f.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-b084048f.zip",
+              "checksum": "SHA-256:a53a555a42613b536af93c3b7f7465921284fc35377a7fac26f46660f4902e05",
+              "size": ""
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/0aad7265be78064dd74d0e9f07147e5b57fe1bf1",
-              "archiveFileName": "esp32-arduino-libs-0aad7265be78064dd74d0e9f07147e5b57fe1bf1.zip",
-              "checksum": "SHA-256:3119601b06dfcfd4cd21b677dbaa593bf9f585966981a5902f86eeb675ab1c92",
-              "size": "307529720"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-b084048f.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-b084048f.zip",
+              "checksum": "SHA-256:a53a555a42613b536af93c3b7f7465921284fc35377a7fac26f46660f4902e05",
+              "size": ""
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: master 2d74741
esp-idf: release/v5.1 b084048faa
arduino: idf-release/v5.1 b78e565f
tinyusb: master 1ba88ff3a
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dl:
espressif__esp-dsp: 1.4.12
espressif__esp-modbus: 1.0.15
espressif__esp-nn: 1.0.2
espressif__esp-tflite-micro: 1.3.1
espressif__esp-zboss-lib: 1.4.0
espressif__esp-zigbee-lib: 1.4.0
espressif__esp32-camera:
espressif__esp_diag_data_store: 1.0.1
espressif__esp_diagnostics: 1.1.0
espressif__esp_insights: 1.1.0
espressif__esp_modem: 1.1.0
espressif__esp_rainmaker: 1.3.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.4.1
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~1
espressif__mdns: 1.3.2
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
joltwallet__littlefs: 1.14.8
espressif__esp-sr: 1.7.1
```
