### PR TITLE
IDF release/v5.1

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-114873b8"
+              "version": "idf-release_v5.1-32b085c7"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-114873b8",
+          "version": "idf-release_v5.1-32b085c7",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
-              "checksum": "SHA-256:4d52826678d7566efc94dca8bd511dfff9fa1273696a12277896984079b6e9b3",
-              "size": "303696571"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-32b085c7.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-32b085c7.zip",
+              "checksum": "SHA-256:3377ab3c2b64be4194f789015c0e8a889288ff8566dc2ed47b4580762c707998",
+              "size": "303696590"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
-              "checksum": "SHA-256:4d52826678d7566efc94dca8bd511dfff9fa1273696a12277896984079b6e9b3",
-              "size": "303696571"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-32b085c7.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-32b085c7.zip",
+              "checksum": "SHA-256:3377ab3c2b64be4194f789015c0e8a889288ff8566dc2ed47b4580762c707998",
+              "size": "303696590"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
-              "checksum": "SHA-256:4d52826678d7566efc94dca8bd511dfff9fa1273696a12277896984079b6e9b3",
-              "size": "303696571"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-32b085c7.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-32b085c7.zip",
+              "checksum": "SHA-256:3377ab3c2b64be4194f789015c0e8a889288ff8566dc2ed47b4580762c707998",
+              "size": "303696590"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
-              "checksum": "SHA-256:4d52826678d7566efc94dca8bd511dfff9fa1273696a12277896984079b6e9b3",
-              "size": "303696571"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-32b085c7.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-32b085c7.zip",
+              "checksum": "SHA-256:3377ab3c2b64be4194f789015c0e8a889288ff8566dc2ed47b4580762c707998",
+              "size": "303696590"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
-              "checksum": "SHA-256:4d52826678d7566efc94dca8bd511dfff9fa1273696a12277896984079b6e9b3",
-              "size": "303696571"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-32b085c7.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-32b085c7.zip",
+              "checksum": "SHA-256:3377ab3c2b64be4194f789015c0e8a889288ff8566dc2ed47b4580762c707998",
+              "size": "303696590"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
-              "checksum": "SHA-256:4d52826678d7566efc94dca8bd511dfff9fa1273696a12277896984079b6e9b3",
-              "size": "303696571"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-32b085c7.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-32b085c7.zip",
+              "checksum": "SHA-256:3377ab3c2b64be4194f789015c0e8a889288ff8566dc2ed47b4580762c707998",
+              "size": "303696590"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
-              "checksum": "SHA-256:4d52826678d7566efc94dca8bd511dfff9fa1273696a12277896984079b6e9b3",
-              "size": "303696571"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-32b085c7.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-32b085c7.zip",
+              "checksum": "SHA-256:3377ab3c2b64be4194f789015c0e8a889288ff8566dc2ed47b4580762c707998",
+              "size": "303696590"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
-              "checksum": "SHA-256:4d52826678d7566efc94dca8bd511dfff9fa1273696a12277896984079b6e9b3",
-              "size": "303696571"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-32b085c7.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-32b085c7.zip",
+              "checksum": "SHA-256:3377ab3c2b64be4194f789015c0e8a889288ff8566dc2ed47b4580762c707998",
+              "size": "303696590"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-dc859c1e67"
+              "version": "idf-release_v5.1-114873b8"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-dc859c1e67",
+          "version": "idf-release_v5.1-114873b8",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/da253aa56255b29a76ac5038db350cd9e4ebde1b",
-              "archiveFileName": "esp32-arduino-libs-da253aa56255b29a76ac5038db350cd9e4ebde1b.zip",
-              "checksum": "SHA-256:a3ce1e1aebe518d6be26006798b44b6c1a0bc8977a8da4d066ed9d9af1378c9e",
-              "size": "307528289"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
+              "checksum": "SHA-256:4d52826678d7566efc94dca8bd511dfff9fa1273696a12277896984079b6e9b3",
+              "size": "303696571"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/da253aa56255b29a76ac5038db350cd9e4ebde1b",
-              "archiveFileName": "esp32-arduino-libs-da253aa56255b29a76ac5038db350cd9e4ebde1b.zip",
-              "checksum": "SHA-256:a3ce1e1aebe518d6be26006798b44b6c1a0bc8977a8da4d066ed9d9af1378c9e",
-              "size": "307528289"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
+              "checksum": "SHA-256:4d52826678d7566efc94dca8bd511dfff9fa1273696a12277896984079b6e9b3",
+              "size": "303696571"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/da253aa56255b29a76ac5038db350cd9e4ebde1b",
-              "archiveFileName": "esp32-arduino-libs-da253aa56255b29a76ac5038db350cd9e4ebde1b.zip",
-              "checksum": "SHA-256:a3ce1e1aebe518d6be26006798b44b6c1a0bc8977a8da4d066ed9d9af1378c9e",
-              "size": "307528289"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
+              "checksum": "SHA-256:4d52826678d7566efc94dca8bd511dfff9fa1273696a12277896984079b6e9b3",
+              "size": "303696571"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/da253aa56255b29a76ac5038db350cd9e4ebde1b",
-              "archiveFileName": "esp32-arduino-libs-da253aa56255b29a76ac5038db350cd9e4ebde1b.zip",
-              "checksum": "SHA-256:a3ce1e1aebe518d6be26006798b44b6c1a0bc8977a8da4d066ed9d9af1378c9e",
-              "size": "307528289"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
+              "checksum": "SHA-256:4d52826678d7566efc94dca8bd511dfff9fa1273696a12277896984079b6e9b3",
+              "size": "303696571"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/da253aa56255b29a76ac5038db350cd9e4ebde1b",
-              "archiveFileName": "esp32-arduino-libs-da253aa56255b29a76ac5038db350cd9e4ebde1b.zip",
-              "checksum": "SHA-256:a3ce1e1aebe518d6be26006798b44b6c1a0bc8977a8da4d066ed9d9af1378c9e",
-              "size": "307528289"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
+              "checksum": "SHA-256:4d52826678d7566efc94dca8bd511dfff9fa1273696a12277896984079b6e9b3",
+              "size": "303696571"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/da253aa56255b29a76ac5038db350cd9e4ebde1b",
-              "archiveFileName": "esp32-arduino-libs-da253aa56255b29a76ac5038db350cd9e4ebde1b.zip",
-              "checksum": "SHA-256:a3ce1e1aebe518d6be26006798b44b6c1a0bc8977a8da4d066ed9d9af1378c9e",
-              "size": "307528289"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
+              "checksum": "SHA-256:4d52826678d7566efc94dca8bd511dfff9fa1273696a12277896984079b6e9b3",
+              "size": "303696571"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/da253aa56255b29a76ac5038db350cd9e4ebde1b",
-              "archiveFileName": "esp32-arduino-libs-da253aa56255b29a76ac5038db350cd9e4ebde1b.zip",
-              "checksum": "SHA-256:a3ce1e1aebe518d6be26006798b44b6c1a0bc8977a8da4d066ed9d9af1378c9e",
-              "size": "307528289"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
+              "checksum": "SHA-256:4d52826678d7566efc94dca8bd511dfff9fa1273696a12277896984079b6e9b3",
+              "size": "303696571"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/da253aa56255b29a76ac5038db350cd9e4ebde1b",
-              "archiveFileName": "esp32-arduino-libs-da253aa56255b29a76ac5038db350cd9e4ebde1b.zip",
-              "checksum": "SHA-256:a3ce1e1aebe518d6be26006798b44b6c1a0bc8977a8da4d066ed9d9af1378c9e",
-              "size": "307528289"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
+              "checksum": "SHA-256:4d52826678d7566efc94dca8bd511dfff9fa1273696a12277896984079b6e9b3",
+              "size": "303696571"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: master 6073bf8
esp-idf: release/v5.1 32b085c747
arduino: idf-release/v5.1 d29bf833
tinyusb: master a615b0a00
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dl:
espressif__esp-dsp: 1.4.12
espressif__esp-modbus: 1.0.15
espressif__esp-nn: 1.0.2
espressif__esp-tflite-micro: 1.3.1
espressif__esp-zboss-lib: 1.4.0
espressif__esp-zigbee-lib: 1.4.0
espressif__esp32-camera:
espressif__esp_diag_data_store: 1.0.1
espressif__esp_diagnostics: 1.1.0
espressif__esp_insights: 1.1.0
espressif__esp_modem: 1.1.0
espressif__esp_rainmaker: 1.3.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.4.1
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~1
espressif__mdns: 1.3.2
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
joltwallet__littlefs: 1.14.8
espressif__esp-sr: 1.7.1
```
