### PR TITLE
IDF release/v5.1

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-32b085c7"
+              "version": "idf-release_v5.1-5a26d8ae"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-32b085c7",
+          "version": "idf-release_v5.1-5a26d8ae",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-32b085c7.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-32b085c7.zip",
-              "checksum": "SHA-256:3377ab3c2b64be4194f789015c0e8a889288ff8566dc2ed47b4580762c707998",
-              "size": "303696590"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-5a26d8ae.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-5a26d8ae.zip",
+              "checksum": "SHA-256:3cddbdb6fc483ded07ccdecd38e1e148e96ebc3eeb076598cc369d1c002ea368",
+              "size": "305853786"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-32b085c7.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-32b085c7.zip",
-              "checksum": "SHA-256:3377ab3c2b64be4194f789015c0e8a889288ff8566dc2ed47b4580762c707998",
-              "size": "303696590"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-5a26d8ae.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-5a26d8ae.zip",
+              "checksum": "SHA-256:3cddbdb6fc483ded07ccdecd38e1e148e96ebc3eeb076598cc369d1c002ea368",
+              "size": "305853786"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-32b085c7.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-32b085c7.zip",
-              "checksum": "SHA-256:3377ab3c2b64be4194f789015c0e8a889288ff8566dc2ed47b4580762c707998",
-              "size": "303696590"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-5a26d8ae.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-5a26d8ae.zip",
+              "checksum": "SHA-256:3cddbdb6fc483ded07ccdecd38e1e148e96ebc3eeb076598cc369d1c002ea368",
+              "size": "305853786"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-32b085c7.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-32b085c7.zip",
-              "checksum": "SHA-256:3377ab3c2b64be4194f789015c0e8a889288ff8566dc2ed47b4580762c707998",
-              "size": "303696590"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-5a26d8ae.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-5a26d8ae.zip",
+              "checksum": "SHA-256:3cddbdb6fc483ded07ccdecd38e1e148e96ebc3eeb076598cc369d1c002ea368",
+              "size": "305853786"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-32b085c7.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-32b085c7.zip",
-              "checksum": "SHA-256:3377ab3c2b64be4194f789015c0e8a889288ff8566dc2ed47b4580762c707998",
-              "size": "303696590"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-5a26d8ae.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-5a26d8ae.zip",
+              "checksum": "SHA-256:3cddbdb6fc483ded07ccdecd38e1e148e96ebc3eeb076598cc369d1c002ea368",
+              "size": "305853786"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-32b085c7.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-32b085c7.zip",
-              "checksum": "SHA-256:3377ab3c2b64be4194f789015c0e8a889288ff8566dc2ed47b4580762c707998",
-              "size": "303696590"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-5a26d8ae.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-5a26d8ae.zip",
+              "checksum": "SHA-256:3cddbdb6fc483ded07ccdecd38e1e148e96ebc3eeb076598cc369d1c002ea368",
+              "size": "305853786"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-32b085c7.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-32b085c7.zip",
-              "checksum": "SHA-256:3377ab3c2b64be4194f789015c0e8a889288ff8566dc2ed47b4580762c707998",
-              "size": "303696590"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-5a26d8ae.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-5a26d8ae.zip",
+              "checksum": "SHA-256:3cddbdb6fc483ded07ccdecd38e1e148e96ebc3eeb076598cc369d1c002ea368",
+              "size": "305853786"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-32b085c7.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-32b085c7.zip",
-              "checksum": "SHA-256:3377ab3c2b64be4194f789015c0e8a889288ff8566dc2ed47b4580762c707998",
-              "size": "303696590"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-5a26d8ae.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-5a26d8ae.zip",
+              "checksum": "SHA-256:3cddbdb6fc483ded07ccdecd38e1e148e96ebc3eeb076598cc369d1c002ea368",
+              "size": "305853786"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-114873b8"
+              "version": "idf-release_v5.1-32b085c7"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-114873b8",
+          "version": "idf-release_v5.1-32b085c7",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
-              "checksum": "SHA-256:4d52826678d7566efc94dca8bd511dfff9fa1273696a12277896984079b6e9b3",
-              "size": "303696571"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-32b085c7.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-32b085c7.zip",
+              "checksum": "SHA-256:3377ab3c2b64be4194f789015c0e8a889288ff8566dc2ed47b4580762c707998",
+              "size": "303696590"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
-              "checksum": "SHA-256:4d52826678d7566efc94dca8bd511dfff9fa1273696a12277896984079b6e9b3",
-              "size": "303696571"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-32b085c7.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-32b085c7.zip",
+              "checksum": "SHA-256:3377ab3c2b64be4194f789015c0e8a889288ff8566dc2ed47b4580762c707998",
+              "size": "303696590"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
-              "checksum": "SHA-256:4d52826678d7566efc94dca8bd511dfff9fa1273696a12277896984079b6e9b3",
-              "size": "303696571"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-32b085c7.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-32b085c7.zip",
+              "checksum": "SHA-256:3377ab3c2b64be4194f789015c0e8a889288ff8566dc2ed47b4580762c707998",
+              "size": "303696590"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
-              "checksum": "SHA-256:4d52826678d7566efc94dca8bd511dfff9fa1273696a12277896984079b6e9b3",
-              "size": "303696571"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-32b085c7.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-32b085c7.zip",
+              "checksum": "SHA-256:3377ab3c2b64be4194f789015c0e8a889288ff8566dc2ed47b4580762c707998",
+              "size": "303696590"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
-              "checksum": "SHA-256:4d52826678d7566efc94dca8bd511dfff9fa1273696a12277896984079b6e9b3",
-              "size": "303696571"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-32b085c7.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-32b085c7.zip",
+              "checksum": "SHA-256:3377ab3c2b64be4194f789015c0e8a889288ff8566dc2ed47b4580762c707998",
+              "size": "303696590"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
-              "checksum": "SHA-256:4d52826678d7566efc94dca8bd511dfff9fa1273696a12277896984079b6e9b3",
-              "size": "303696571"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-32b085c7.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-32b085c7.zip",
+              "checksum": "SHA-256:3377ab3c2b64be4194f789015c0e8a889288ff8566dc2ed47b4580762c707998",
+              "size": "303696590"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
-              "checksum": "SHA-256:4d52826678d7566efc94dca8bd511dfff9fa1273696a12277896984079b6e9b3",
-              "size": "303696571"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-32b085c7.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-32b085c7.zip",
+              "checksum": "SHA-256:3377ab3c2b64be4194f789015c0e8a889288ff8566dc2ed47b4580762c707998",
+              "size": "303696590"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
-              "checksum": "SHA-256:4d52826678d7566efc94dca8bd511dfff9fa1273696a12277896984079b6e9b3",
-              "size": "303696571"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-32b085c7.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-32b085c7.zip",
+              "checksum": "SHA-256:3377ab3c2b64be4194f789015c0e8a889288ff8566dc2ed47b4580762c707998",
+              "size": "303696590"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-dc859c1e67"
+              "version": "idf-release_v5.1-114873b8"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-dc859c1e67",
+          "version": "idf-release_v5.1-114873b8",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/da253aa56255b29a76ac5038db350cd9e4ebde1b",
-              "archiveFileName": "esp32-arduino-libs-da253aa56255b29a76ac5038db350cd9e4ebde1b.zip",
-              "checksum": "SHA-256:a3ce1e1aebe518d6be26006798b44b6c1a0bc8977a8da4d066ed9d9af1378c9e",
-              "size": "307528289"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
+              "checksum": "SHA-256:4d52826678d7566efc94dca8bd511dfff9fa1273696a12277896984079b6e9b3",
+              "size": "303696571"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/da253aa56255b29a76ac5038db350cd9e4ebde1b",
-              "archiveFileName": "esp32-arduino-libs-da253aa56255b29a76ac5038db350cd9e4ebde1b.zip",
-              "checksum": "SHA-256:a3ce1e1aebe518d6be26006798b44b6c1a0bc8977a8da4d066ed9d9af1378c9e",
-              "size": "307528289"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
+              "checksum": "SHA-256:4d52826678d7566efc94dca8bd511dfff9fa1273696a12277896984079b6e9b3",
+              "size": "303696571"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/da253aa56255b29a76ac5038db350cd9e4ebde1b",
-              "archiveFileName": "esp32-arduino-libs-da253aa56255b29a76ac5038db350cd9e4ebde1b.zip",
-              "checksum": "SHA-256:a3ce1e1aebe518d6be26006798b44b6c1a0bc8977a8da4d066ed9d9af1378c9e",
-              "size": "307528289"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
+              "checksum": "SHA-256:4d52826678d7566efc94dca8bd511dfff9fa1273696a12277896984079b6e9b3",
+              "size": "303696571"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/da253aa56255b29a76ac5038db350cd9e4ebde1b",
-              "archiveFileName": "esp32-arduino-libs-da253aa56255b29a76ac5038db350cd9e4ebde1b.zip",
-              "checksum": "SHA-256:a3ce1e1aebe518d6be26006798b44b6c1a0bc8977a8da4d066ed9d9af1378c9e",
-              "size": "307528289"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
+              "checksum": "SHA-256:4d52826678d7566efc94dca8bd511dfff9fa1273696a12277896984079b6e9b3",
+              "size": "303696571"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/da253aa56255b29a76ac5038db350cd9e4ebde1b",
-              "archiveFileName": "esp32-arduino-libs-da253aa56255b29a76ac5038db350cd9e4ebde1b.zip",
-              "checksum": "SHA-256:a3ce1e1aebe518d6be26006798b44b6c1a0bc8977a8da4d066ed9d9af1378c9e",
-              "size": "307528289"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
+              "checksum": "SHA-256:4d52826678d7566efc94dca8bd511dfff9fa1273696a12277896984079b6e9b3",
+              "size": "303696571"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/da253aa56255b29a76ac5038db350cd9e4ebde1b",
-              "archiveFileName": "esp32-arduino-libs-da253aa56255b29a76ac5038db350cd9e4ebde1b.zip",
-              "checksum": "SHA-256:a3ce1e1aebe518d6be26006798b44b6c1a0bc8977a8da4d066ed9d9af1378c9e",
-              "size": "307528289"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
+              "checksum": "SHA-256:4d52826678d7566efc94dca8bd511dfff9fa1273696a12277896984079b6e9b3",
+              "size": "303696571"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/da253aa56255b29a76ac5038db350cd9e4ebde1b",
-              "archiveFileName": "esp32-arduino-libs-da253aa56255b29a76ac5038db350cd9e4ebde1b.zip",
-              "checksum": "SHA-256:a3ce1e1aebe518d6be26006798b44b6c1a0bc8977a8da4d066ed9d9af1378c9e",
-              "size": "307528289"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
+              "checksum": "SHA-256:4d52826678d7566efc94dca8bd511dfff9fa1273696a12277896984079b6e9b3",
+              "size": "303696571"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/da253aa56255b29a76ac5038db350cd9e4ebde1b",
-              "archiveFileName": "esp32-arduino-libs-da253aa56255b29a76ac5038db350cd9e4ebde1b.zip",
-              "checksum": "SHA-256:a3ce1e1aebe518d6be26006798b44b6c1a0bc8977a8da4d066ed9d9af1378c9e",
-              "size": "307528289"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-114873b8.zip",
+              "checksum": "SHA-256:4d52826678d7566efc94dca8bd511dfff9fa1273696a12277896984079b6e9b3",
+              "size": "303696571"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-5a26d8ae"
+              "version": "idf-release_v5.1-9439479f-v1"
             },
             {
               "packager": "esp32",
@@ -77,7 +77,7 @@
             {
               "packager": "esp32",
               "name": "openocd-esp32",
-              "version": "v0.12.0-esp32-20240318"
+              "version": "v0.12.0-esp32-20241016"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-5a26d8ae",
+          "version": "idf-release_v5.1-9439479f-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-5a26d8ae.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-5a26d8ae.zip",
-              "checksum": "SHA-256:3cddbdb6fc483ded07ccdecd38e1e148e96ebc3eeb076598cc369d1c002ea368",
-              "size": "305853786"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f-v1.zip",
+              "checksum": "SHA-256:083e4bf5d4b1ea8f8bf8759ddba7c21da7707a4fc5f0b94425387648833a9291",
+              "size": "305390078"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-5a26d8ae.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-5a26d8ae.zip",
-              "checksum": "SHA-256:3cddbdb6fc483ded07ccdecd38e1e148e96ebc3eeb076598cc369d1c002ea368",
-              "size": "305853786"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f-v1.zip",
+              "checksum": "SHA-256:083e4bf5d4b1ea8f8bf8759ddba7c21da7707a4fc5f0b94425387648833a9291",
+              "size": "305390078"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-5a26d8ae.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-5a26d8ae.zip",
-              "checksum": "SHA-256:3cddbdb6fc483ded07ccdecd38e1e148e96ebc3eeb076598cc369d1c002ea368",
-              "size": "305853786"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f-v1.zip",
+              "checksum": "SHA-256:083e4bf5d4b1ea8f8bf8759ddba7c21da7707a4fc5f0b94425387648833a9291",
+              "size": "305390078"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-5a26d8ae.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-5a26d8ae.zip",
-              "checksum": "SHA-256:3cddbdb6fc483ded07ccdecd38e1e148e96ebc3eeb076598cc369d1c002ea368",
-              "size": "305853786"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f-v1.zip",
+              "checksum": "SHA-256:083e4bf5d4b1ea8f8bf8759ddba7c21da7707a4fc5f0b94425387648833a9291",
+              "size": "305390078"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-5a26d8ae.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-5a26d8ae.zip",
-              "checksum": "SHA-256:3cddbdb6fc483ded07ccdecd38e1e148e96ebc3eeb076598cc369d1c002ea368",
-              "size": "305853786"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f-v1.zip",
+              "checksum": "SHA-256:083e4bf5d4b1ea8f8bf8759ddba7c21da7707a4fc5f0b94425387648833a9291",
+              "size": "305390078"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-5a26d8ae.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-5a26d8ae.zip",
-              "checksum": "SHA-256:3cddbdb6fc483ded07ccdecd38e1e148e96ebc3eeb076598cc369d1c002ea368",
-              "size": "305853786"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f-v1.zip",
+              "checksum": "SHA-256:083e4bf5d4b1ea8f8bf8759ddba7c21da7707a4fc5f0b94425387648833a9291",
+              "size": "305390078"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-5a26d8ae.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-5a26d8ae.zip",
-              "checksum": "SHA-256:3cddbdb6fc483ded07ccdecd38e1e148e96ebc3eeb076598cc369d1c002ea368",
-              "size": "305853786"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f-v1.zip",
+              "checksum": "SHA-256:083e4bf5d4b1ea8f8bf8759ddba7c21da7707a4fc5f0b94425387648833a9291",
+              "size": "305390078"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/lucasssvaz/esp32-arduino-libs/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-5a26d8ae.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-5a26d8ae.zip",
-              "checksum": "SHA-256:3cddbdb6fc483ded07ccdecd38e1e148e96ebc3eeb076598cc369d1c002ea368",
-              "size": "305853786"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f-v1.zip",
+              "checksum": "SHA-256:083e4bf5d4b1ea8f8bf8759ddba7c21da7707a4fc5f0b94425387648833a9291",
+              "size": "305390078"
             }
           ]
         },
@@ -539,56 +539,56 @@
         },
         {
           "name": "openocd-esp32",
-          "version": "v0.12.0-esp32-20240318",
+          "version": "v0.12.0-esp32-20241016",
           "systems": [
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20240318/openocd-esp32-linux-amd64-0.12.0-esp32-20240318.tar.gz",
-              "archiveFileName": "openocd-esp32-linux-amd64-0.12.0-esp32-20240318.tar.gz",
-              "checksum": "SHA-256:cf26c5cef4f6b04aa23cd2778675604e5a74a4ce4d8d17b854d05fbcb782d52c",
-              "size": "2252682"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20241016/openocd-esp32-linux-amd64-0.12.0-esp32-20241016.tar.gz",
+              "archiveFileName": "openocd-esp32-linux-amd64-0.12.0-esp32-20241016.tar.gz",
+              "checksum": "SHA-256:e82b0f036dc99244bead5f09a86e91bb2365cbcd1122ac68261e5647942485df",
+              "size": "2398717"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20240318/openocd-esp32-linux-arm64-0.12.0-esp32-20240318.tar.gz",
-              "archiveFileName": "openocd-esp32-linux-arm64-0.12.0-esp32-20240318.tar.gz",
-              "checksum": "SHA-256:9b97a37aa2cab94424a778c25c0b4aa0f90d6ef9cda764a1d9289d061305f4b7",
-              "size": "2132904"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20241016/openocd-esp32-linux-arm64-0.12.0-esp32-20241016.tar.gz",
+              "archiveFileName": "openocd-esp32-linux-arm64-0.12.0-esp32-20241016.tar.gz",
+              "checksum": "SHA-256:8f8daf5bd22ec5d2fa9257b0862ec33da18ee677e023fb9a9eb17f74ce208c76",
+              "size": "2271584"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20240318/openocd-esp32-linux-armel-0.12.0-esp32-20240318.tar.gz",
-              "archiveFileName": "openocd-esp32-linux-armel-0.12.0-esp32-20240318.tar.gz",
-              "checksum": "SHA-256:b7e82776ec374983807d3389df09c632ad9bc8341f2075690b6b500319dfeaf4",
-              "size": "2271761"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20241016/openocd-esp32-linux-armel-0.12.0-esp32-20241016.tar.gz",
+              "archiveFileName": "openocd-esp32-linux-armel-0.12.0-esp32-20241016.tar.gz",
+              "checksum": "SHA-256:bc9c020ecf20e2000f76cffa44305fd5bc44d2e688ea78cce423399d33f19767",
+              "size": "2414206"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20240318/openocd-esp32-macos-0.12.0-esp32-20240318.tar.gz",
-              "archiveFileName": "openocd-esp32-macos-0.12.0-esp32-20240318.tar.gz",
-              "checksum": "SHA-256:b16c3082c94df1079367c44d99f7a8605534cd48aabc18898e46e94a2c8c57e7",
-              "size": "2365588"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20241016/openocd-esp32-macos-0.12.0-esp32-20241016.tar.gz",
+              "archiveFileName": "openocd-esp32-macos-0.12.0-esp32-20241016.tar.gz",
+              "checksum": "SHA-256:02a2dffe801a2d005fa9e614d80ff8173395b2cb0b5d3118d0229d094a9946a7",
+              "size": "2508089"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20240318/openocd-esp32-macos-arm64-0.12.0-esp32-20240318.tar.gz",
-              "archiveFileName": "openocd-esp32-macos-arm64-0.12.0-esp32-20240318.tar.gz",
-              "checksum": "SHA-256:534ec925ae6e35e869e4e4e6e4d2c4a1eb081f97ebcc2dd5efdc52d12f4c2f86",
-              "size": "2406377"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20241016/openocd-esp32-macos-arm64-0.12.0-esp32-20241016.tar.gz",
+              "archiveFileName": "openocd-esp32-macos-arm64-0.12.0-esp32-20241016.tar.gz",
+              "checksum": "SHA-256:c382f9e884d6565cb6089bff5f200f4810994667d885f062c3d3c5625a0fa9d6",
+              "size": "2552569"
             },
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20240318/openocd-esp32-win32-0.12.0-esp32-20240318.zip",
-              "archiveFileName": "openocd-esp32-win32-0.12.0-esp32-20240318.zip",
-              "checksum": "SHA-256:d379329eba052435173ab0d69c9b15bc164a6ce489e2a67cd11169d2dabff633",
-              "size": "2783915"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20241016/openocd-esp32-win32-0.12.0-esp32-20241016.zip",
+              "archiveFileName": "openocd-esp32-win32-0.12.0-esp32-20241016.zip",
+              "checksum": "SHA-256:3b5d615e0a72cc771a45dd469031312d5881c01d7b6bc9edb29b8b6bda8c2e90",
+              "size": "2946244"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20240318/openocd-esp32-win32-0.12.0-esp32-20240318.zip",
-              "archiveFileName": "openocd-esp32-win32-0.12.0-esp32-20240318.zip",
-              "checksum": "SHA-256:d379329eba052435173ab0d69c9b15bc164a6ce489e2a67cd11169d2dabff633",
-              "size": "2783915"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20241016/openocd-esp32-win64-0.12.0-esp32-20241016.zip",
+              "archiveFileName": "openocd-esp32-win64-0.12.0-esp32-20241016.zip",
+              "checksum": "SHA-256:5e7b2fd1947d3a8625f6a11db7a2340cf2f41ff4c61284c022c7d7c32b18780a",
+              "size": "2946244"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: release/v5.1 e9ebb3c
esp-idf: release/v5.1 9439479fe5
arduino: idf-release/v5.1 006f33b23
tinyusb: master 0569188ae
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dl:
espressif__esp-dsp: 1.5.2
espressif__esp-modbus: 1.0.16
espressif__esp-nn: 1.1.0
espressif__esp-serial-flasher: 0.0.11
espressif__esp-tflite-micro: 1.3.2
espressif__esp-zboss-lib: 1.6.0
espressif__esp-zigbee-lib: 1.6.0
espressif__esp32-camera:
espressif__esp_diag_data_store: 1.0.2
espressif__esp_diagnostics: 1.2.1
espressif__esp_insights: 1.2.2
espressif__esp_modem: 1.2.0
espressif__esp_rainmaker: 1.5.1
espressif__esp_rcp_update: 1.2.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.5.0
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~1
espressif__mdns: 1.4.2
espressif__network_provisioning: 1.0.3
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
joltwallet__littlefs: 1.14.8
espressif__esp-dsp: 1.4.12
espressif__esp-sr: 1.9.4
```
