### PR TITLE
IDF release/v5.1

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-9439479f"
+              "version": "idf-release_v5.1-9439479f-v1"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-9439479f",
+          "version": "idf-release_v5.1-9439479f-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f.zip",
-              "checksum": "SHA-256:f9db39bdd827ff449691ac8913b3f459ee3e73353db853547b9ccc3906335a64",
-              "size": "305294843"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f-v1.zip",
+              "checksum": "SHA-256:6b1a5fe4968fad2fa505edb2db3b39a51b89c32aabccec99ed475f488adaaab4",
+              "size": "305390073"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f.zip",
-              "checksum": "SHA-256:f9db39bdd827ff449691ac8913b3f459ee3e73353db853547b9ccc3906335a64",
-              "size": "305294843"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f-v1.zip",
+              "checksum": "SHA-256:6b1a5fe4968fad2fa505edb2db3b39a51b89c32aabccec99ed475f488adaaab4",
+              "size": "305390073"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f.zip",
-              "checksum": "SHA-256:f9db39bdd827ff449691ac8913b3f459ee3e73353db853547b9ccc3906335a64",
-              "size": "305294843"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f-v1.zip",
+              "checksum": "SHA-256:6b1a5fe4968fad2fa505edb2db3b39a51b89c32aabccec99ed475f488adaaab4",
+              "size": "305390073"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f.zip",
-              "checksum": "SHA-256:f9db39bdd827ff449691ac8913b3f459ee3e73353db853547b9ccc3906335a64",
-              "size": "305294843"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f-v1.zip",
+              "checksum": "SHA-256:6b1a5fe4968fad2fa505edb2db3b39a51b89c32aabccec99ed475f488adaaab4",
+              "size": "305390073"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f.zip",
-              "checksum": "SHA-256:f9db39bdd827ff449691ac8913b3f459ee3e73353db853547b9ccc3906335a64",
-              "size": "305294843"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f-v1.zip",
+              "checksum": "SHA-256:6b1a5fe4968fad2fa505edb2db3b39a51b89c32aabccec99ed475f488adaaab4",
+              "size": "305390073"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f.zip",
-              "checksum": "SHA-256:f9db39bdd827ff449691ac8913b3f459ee3e73353db853547b9ccc3906335a64",
-              "size": "305294843"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f-v1.zip",
+              "checksum": "SHA-256:6b1a5fe4968fad2fa505edb2db3b39a51b89c32aabccec99ed475f488adaaab4",
+              "size": "305390073"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f.zip",
-              "checksum": "SHA-256:f9db39bdd827ff449691ac8913b3f459ee3e73353db853547b9ccc3906335a64",
-              "size": "305294843"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f-v1.zip",
+              "checksum": "SHA-256:6b1a5fe4968fad2fa505edb2db3b39a51b89c32aabccec99ed475f488adaaab4",
+              "size": "305390073"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f.zip",
-              "checksum": "SHA-256:f9db39bdd827ff449691ac8913b3f459ee3e73353db853547b9ccc3906335a64",
-              "size": "305294843"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f-v1.zip",
+              "checksum": "SHA-256:6b1a5fe4968fad2fa505edb2db3b39a51b89c32aabccec99ed475f488adaaab4",
+              "size": "305390073"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-9439479f-v1"
+              "version": "idf-release_v5.1-9439479f-v2"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-9439479f-v1",
+          "version": "idf-release_v5.1-9439479f-v2",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/lucasssvaz/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f-v1.zip",
-              "checksum": "SHA-256:6b1a5fe4968fad2fa505edb2db3b39a51b89c32aabccec99ed475f488adaaab4",
-              "size": "305390073"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f-v2.zip",
+              "checksum": "SHA-256:8af9002742004530e337e28ba7c73b67ba3b2f5613801d84621aaebecbaea6fe",
+              "size": "305390091"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/lucasssvaz/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f-v1.zip",
-              "checksum": "SHA-256:6b1a5fe4968fad2fa505edb2db3b39a51b89c32aabccec99ed475f488adaaab4",
-              "size": "305390073"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f-v2.zip",
+              "checksum": "SHA-256:8af9002742004530e337e28ba7c73b67ba3b2f5613801d84621aaebecbaea6fe",
+              "size": "305390091"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/lucasssvaz/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f-v1.zip",
-              "checksum": "SHA-256:6b1a5fe4968fad2fa505edb2db3b39a51b89c32aabccec99ed475f488adaaab4",
-              "size": "305390073"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f-v2.zip",
+              "checksum": "SHA-256:8af9002742004530e337e28ba7c73b67ba3b2f5613801d84621aaebecbaea6fe",
+              "size": "305390091"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/lucasssvaz/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f-v1.zip",
-              "checksum": "SHA-256:6b1a5fe4968fad2fa505edb2db3b39a51b89c32aabccec99ed475f488adaaab4",
-              "size": "305390073"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f-v2.zip",
+              "checksum": "SHA-256:8af9002742004530e337e28ba7c73b67ba3b2f5613801d84621aaebecbaea6fe",
+              "size": "305390091"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/lucasssvaz/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f-v1.zip",
-              "checksum": "SHA-256:6b1a5fe4968fad2fa505edb2db3b39a51b89c32aabccec99ed475f488adaaab4",
-              "size": "305390073"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f-v2.zip",
+              "checksum": "SHA-256:8af9002742004530e337e28ba7c73b67ba3b2f5613801d84621aaebecbaea6fe",
+              "size": "305390091"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/lucasssvaz/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f-v1.zip",
-              "checksum": "SHA-256:6b1a5fe4968fad2fa505edb2db3b39a51b89c32aabccec99ed475f488adaaab4",
-              "size": "305390073"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f-v2.zip",
+              "checksum": "SHA-256:8af9002742004530e337e28ba7c73b67ba3b2f5613801d84621aaebecbaea6fe",
+              "size": "305390091"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/lucasssvaz/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f-v1.zip",
-              "checksum": "SHA-256:6b1a5fe4968fad2fa505edb2db3b39a51b89c32aabccec99ed475f488adaaab4",
-              "size": "305390073"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f-v2.zip",
+              "checksum": "SHA-256:8af9002742004530e337e28ba7c73b67ba3b2f5613801d84621aaebecbaea6fe",
+              "size": "305390091"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/lucasssvaz/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f-v1.zip",
-              "checksum": "SHA-256:6b1a5fe4968fad2fa505edb2db3b39a51b89c32aabccec99ed475f488adaaab4",
-              "size": "305390073"
+              "url": "https://github.com/lucasssvaz/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f-v2.zip",
+              "checksum": "SHA-256:8af9002742004530e337e28ba7c73b67ba3b2f5613801d84621aaebecbaea6fe",
+              "size": "305390091"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: release/v5.1 715dac4
esp-idf: release/v5.1 9439479fe5
arduino: release/v3.0.x 788326dd2
tinyusb: master 0569188ae
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dl:
espressif__esp-dsp: 1.5.2
espressif__esp-modbus: 1.0.16
espressif__esp-nn: 1.1.0
espressif__esp-serial-flasher: 0.0.11
espressif__esp-tflite-micro: 1.3.2
espressif__esp-zboss-lib: 1.6.0
espressif__esp-zigbee-lib: 1.6.0
espressif__esp32-camera:
espressif__esp_diag_data_store: 1.0.2
espressif__esp_diagnostics: 1.2.1
espressif__esp_insights: 1.2.2
espressif__esp_modem: 1.2.0
espressif__esp_rainmaker: 1.5.1
espressif__esp_rcp_update: 1.2.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.5.0
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~1
espressif__mdns: 1.4.2
espressif__network_provisioning: 1.0.3
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
joltwallet__littlefs: 1.14.8
espressif__esp-dsp: 1.4.12
espressif__esp-sr: 1.9.4
```
